### PR TITLE
ETL-Backup Script Updates -  Addition of Shellcheck and Github Actions to lint scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: Shell Lint
+
+# Lint on every push and on PRs that touch shell files or the Makefile
+on:
+  push:
+    paths:
+      - "**.sh"
+      - "Makefile"
+  pull_request:
+    paths:
+      - "**.sh"
+      - "Makefile"
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck & make
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y shellcheck make
+
+      - name: Run shellcheck via Makefile
+        run: make shellcheck

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,4 +25,17 @@ jobs:
           sudo apt-get install -y shellcheck make
 
       - name: Run shellcheck via Makefile
-        run: make shellcheck
+        run: |
+          make shellcheck > sc.log 
+          if [ -s sc.log ]; then
+            {
+              echo '### ShellCheck report'
+              echo ''
+              echo '```'
+              cat sc.log
+              echo '```'
+            } >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo ':green_circle: No issues found' >>"$GITHUB_STEP_SUMMARY"
+          fi
+

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ SHELL_SCRIPTS := $(shell find . -type f -name '*.sh' -not -path './.git/*')
 .PHONY: shellcheck
 shellcheck:
 	@echo "Running shellcheck on $(words $(SHELL_SCRIPTS)) script(s)…"
-	@shellcheck -x -o all $(SHELL_SCRIPTS) || true
+	@shellcheck -x -o all -f gcc $(SHELL_SCRIPTS) || true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+# List every *.sh script in the repo, skipping the .git directory.
+SHELL_SCRIPTS := $(shell find . -type f -name '*.sh' -not -path './.git/*')
+
+.PHONY: shellcheck
+shellcheck:
+	@echo "🔍  Running shellcheck on $(words $(SHELL_SCRIPTS)) script(s)…"
+	@# -x follows sourced files; -o all enables all optional warnings
+	@shellcheck -x -o all $(SHELL_SCRIPTS)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,5 @@ SHELL_SCRIPTS := $(shell find . -type f -name '*.sh' -not -path './.git/*')
 
 .PHONY: shellcheck
 shellcheck:
-	@echo "🔍  Running shellcheck on $(words $(SHELL_SCRIPTS)) script(s)…"
-	@# -x follows sourced files; -o all enables all optional warnings
-	@shellcheck -x -o all $(SHELL_SCRIPTS)
+	@echo "Running shellcheck on $(words $(SHELL_SCRIPTS)) script(s)…"
+	@shellcheck -x -o all $(SHELL_SCRIPTS) || true

--- a/aggregator-backup/download-aggregator.sh
+++ b/aggregator-backup/download-aggregator.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 # Temporary Directory Name
 tmpDir=kc-aggregator-tmp
 
-if [ -d "${tmpDir}" ]; then
+if [[ -d "${tmpDir}" ]]; then
     echo "Temp dir '${tmpDir}' already exists. Please manually remove it before running this script."
     exit 1
 fi
@@ -23,13 +23,13 @@ aggDir="${2:-/var/configs/waterfowl/duckdb}"
 currentContext="$(kubectl config current-context)"
 
 echo "This script will downlaod the Aggregator Read DB using the following:"
-echo "  Kubectl Context: $currentContext"
-echo "  Namespace: $namespace"
-echo "  Kubecost Aggregator Directory: $aggDir"
+echo "  Kubectl Context: ${currentContext}"
+echo "  Namespace: ${namespace}"
+echo "  Kubecost Aggregator Directory: ${aggDir}"
 echo -n "Would you like to continue [y/N]? "
 read -r r
 
-if [ "$r" == "${r#[y]}" ]; then
+if [[ "${r}" == "${r#[y]}" ]]; then
   echo "Exiting..."
   exit 0
 fi
@@ -38,33 +38,33 @@ fi
 # If you use zsh and this line isn't working, it is likely due to your partial line response
 # and zsh adds a % delimeter to the end. Add the following line to your ~/.zshrc file:
 # PROMPT_EOL_MARK=''
-podName="$(kubectl get pods -n "$namespace" -l app=aggregator -o jsonpath='{.items[0].metadata.name}')"
-echo "Aggregator PodName: $podName"
+podName="$(kubectl get pods -n "${namespace}" -l app=aggregator -o jsonpath='{.items[0].metadata.name}')"
+echo "Aggregator PodName: ${podName}"
 
 # Find read DB file using ls and awk commands to get the absolute path
-readDbFile="$(kubectl exec -c aggregator "$podName" -n "$namespace" -- ls -Rlt /var/configs/waterfowl | awk '/:$/ {dir=substr($0, 1, length($0)-1)} /read/ && !/:$/ {print dir "/" $NF}' | head -n 1)"
-echo "Found read db file: $readDbFile"
+readDbFile="$(kubectl exec -c aggregator "${podName}" -n "${namespace}" -- ls -Rlt /var/configs/waterfowl | awk '/:$/ {dir=substr($0, 1, length($0)-1)} /read/ && !/:$/ {print dir "/" $NF}' | head -n 1)"
+echo "Found read db file: ${readDbFile}"
 
 # Download file from container and store it in the same filename in current directory
-echo "Copying aggregator Files from $namespace/$podName:$aggDir to $tmpDir... creates $tmpDir if does not exist"
+echo "Copying aggregator Files from ${namespace}/${podName}:${aggDir} to ${tmpDir}... creates ${tmpDir} if does not exist"
 
 # Create temporary directory if it doesn't exist
-mkdir -p "./$tmpDir"
+mkdir -p "./${tmpDir}"
 
-kubectl exec -c aggregator "$podName" -n "$namespace" -- bash -c "base64 $readDbFile" > "./$tmpDir/$podName.read.b64"
+kubectl exec -c aggregator "${podName}" -n "${namespace}" -- bash -c "base64 ${readDbFile}" > "./${tmpDir}/${podName}.read.b64"
 
 # Then decode it locally
-base64 -d -i "./$tmpDir/$podName.read.b64" -o "./$tmpDir/$podName.read"
+base64 -d -i "./${tmpDir}/${podName}.read.b64" -o "./${tmpDir}/${podName}.read"
 
 # Clean up the base64 encoded file
-rm "./$tmpDir/$podName.read.b64"
+rm "./${tmpDir}/${podName}.read.b64"
 
 # Archive the directory
-tar cfz kubecost-aggregator.tar.gz $tmpDir && \
+tar cfz kubecost-aggregator.tar.gz "${tmpDir}" && \
   echo "Archive created successfully" || \
   echo "Failed to create archive\nNote: if you have an error like: Cannot stat: No such file or directory\nYou will need to run the script again because the Read-DB changed while running the script."
 # Delete the temporary directory
-rm -rf $tmpDir
+rm -rf "${tmpDir}"
 
 # Log final messages
 echo "DB Archive Created kubecost-aggregator.tar.gz"

--- a/aggregator-backup/upload-aggregator.sh
+++ b/aggregator-backup/upload-aggregator.sh
@@ -9,34 +9,34 @@ set -eo pipefail
 # Temporary Directory Name
 tmpDir=kc-aggregator-tmp
 
-if [ -d "${tmpDir}" ]; then
+if [[ -d "${tmpDir}" ]]; then
     echo "Temp dir '${tmpDir}' already exists. Please manually remove it before running this script."
     exit 1
 fi
 
 # Accept Optional Namespace -- default to kubecost
 namespace=$1
-if [ "$namespace" == "" ]; then
+if [[ "${namespace}" == "" ]]; then
   namespace=kubecost
 fi
 
 # Accept Optional aggregator Store Directory -- default to aggDir=/var/configs/waterfowl/duckdb
 aggDir=$2
-if [ "$aggDir" == "" ]; then
+if [[ "${aggDir}" == "" ]]; then
   aggDir=aggDir=/var/configs/waterfowl/duckdb
 fi
 
 # Accept aggregator .tar file to upload
 aggFile=$3
-if [ "$aggFile" == "" ]; then
+if [[ "${aggFile}" == "" ]]; then
   aggFile=kubecost-aggregator.tar.gz
 fi
 
-if [ -f "$aggFile" ]
+if [[ -f "${aggFile}" ]]
 then
-  echo " $aggFile found, continuing."
+  echo " ${aggFile} found, continuing."
 else
-  echo " File: $aggFile does not exist, please check your file, and try again."
+  echo " File: ${aggFile} does not exist, please check your file, and try again."
   exit 1
 fi
 
@@ -52,108 +52,108 @@ echo "  1 Load data in Read only mode (no derivation)"
 echo "  2 Load Read data in over write data and re-derive"
 echo "  3 Load read/write data as it is in the backup and manually interact"
 echo -n "Choose an option [1/2/3]: "
-read o
-if [ "$o" == "1" ]; then
+read -r o
+if [[ "${o}" == "1" ]]; then
   ro=1
 fi
-if [ "$o" == "2" ]; then
+if [[ "${o}" == "2" ]]; then
   derive=1
 fi
-if [ "$o" == "3" ]; then
+if [[ "${o}" == "3" ]]; then
   copy=1
 fi
 
-if [ $ro -eq 0 -a $derive -eq 0 -a $copy -eq 0 ]; then
+if [[ "${ro}" -eq 0 && "${derive}" -eq 0 && "${copy}" -eq 0 ]]; then
   echo "  Must select option 1/2/3 to continue. Please try again."
   exit 1
 fi
 
 
 echo "This script will delete the Kubecost aggregator storage and replace it with aggregator files using the following:"
-echo "  Kubectl Context: $currentContext"
-echo "  Namespace: $namespace"
-echo "  ETL File (source): $aggFile"
-echo "  ETL Directory (destination): $aggDir"
-if [ $ro -eq 1 ]; then
+echo "  Kubectl Context: ${currentContext}"
+echo "  Namespace: ${namespace}"
+echo "  ETL File (source): ${aggFile}"
+echo "  ETL Directory (destination): ${aggDir}"
+if [[ "${ro}" -eq 1 ]]; then
   echo "  Mode: Copy files and set pod to read-only - no derivation..."
 fi
 
-if [ $derive -eq 1 ]; then
+if [[ "${derive}" -eq 1 ]]; then
   echo "  Mode: Copy read file over the write file and derive data..."
 fi
 
-if [ $copy -eq 1 ]; then
+if [[ "${copy}" -eq 1 ]]; then
   echo "  Mode: Copy file as is..."
 fi
 
 echo -n "Would you like to continue [y/N]? "
-read r
+read -r r
 
-if [ "$r" == "${r#[y]}" ]; then
+if [[ "${r}" == "${r#[y]}" ]]; then
   echo "Exiting..."
   exit 0
 fi
 
-fileToSendToContainer=$aggFile
-if [ $derive -eq 1 ]; then
+fileToSendToContainer=${aggFile}
+if [[ "${derive}" -eq 1 ]]; then
   # Prepare files for option selected above.
-  tar xzf $aggFile
-  pushd $tmpDir
-  readFile=`ls | grep "read"`
-  writeFile=`ls | grep "write"`
-  echo "  Replacing $writeFile with $readFile"
-  rm -rf $writeFile
-  cp $readFile $writeFile
+  tar xzf "${aggFile}"
+  pushd "${tmpDir}"
+  readFile=$(ls | grep "read")
+  writeFile=$(ls | grep "write")
+  echo "  Replacing ${writeFile} with ${readFile}"
+  rm -rf "${writeFile}"
+  cp "${readFile}" "${writeFile}"
   for i in $(ls -d */);
   do
-    if [[ $i = v* ]]; then
-      readFile="$(ls $i | grep 'read')"
-      writeFile="$(ls $i | grep 'write')"
-      echo "  Replacing $i/$writeFile with $i/$readFile"
-      rm -rf $i/$writeFile
-      cp $i/$readFile $i/$writeFile
+    if [[ ${i} = v* ]]; then
+      readFile="$(ls "${i}" | grep 'read')"
+      writeFile="$(ls "${i}" | grep 'write')"
+      echo "  Replacing ${i}/${writeFile} with ${i}/${readFile}"
+      rm -rf "${i}"/"${writeFile}"
+      cp "${i}"/"${readFile}" "${i}"/"${writeFile}"
     fi
   done
   popd
   fileToSendToContainer=kubecost-aggregator-$(date +"%s").tar.gz
-  tar cfz $fileToSendToContainer $tmpDir
-  rm -rf $tmpDir
+  tar cfz "${fileToSendToContainer}" "${tmpDir}"
+  rm -rf "${tmpDir}"
 fi
 
 
 
 
 # Grab the Pod Name of the aggregator pod
-podName=`kubectl get pods -n $namespace -l app=aggregator -o jsonpath='{.items[0].metadata.name}'`
+podName=$(kubectl get pods -n "${namespace}" -l app=aggregator -o jsonpath='{.items[0].metadata.name}')
 
 # Grab the Deployment name of the aggregator pod
-deployName=`kubectl get deploy -n $namespace -l app=aggregator -o jsonpath='{.items[0].metadata.name}'`
+deployName=$(kubectl get deploy -n "${namespace}" -l app=aggregator -o jsonpath='{.items[0].metadata.name}')
 
 # Copy the Files to tmp directory
-echo "Copying aggregator Files from $aggFile to $podName..."
-kubectl cp -c cost-model $aggFile $namespace/$podName:/var/configs/kubecost-aggregator.tar.gz
+echo "Copying aggregator Files from ${aggFile} to ${podName}..."
+kubectl cp -c cost-model "${aggFile}" "${namespace}"/"${podName}":/var/configs/kubecost-aggregator.tar.gz
 
 # Exec into the pod and replace the ETL
-echo "Execing into the pod and replacing $aggDir "
+echo "Execing into the pod and replacing ${aggDir} "
 set -e
-kubectl exec -n $namespace pod/$podName -- ash -c " \
-  rm -rf /var/configs/$tmpDir && \
+kubectl exec -n "${namespace}" pod/"${podName}" -- ash -c " \
+  rm -rf /var/configs/${tmpDir} && \
   tar xzf /var/configs/kubecost-aggregator.tar.gz --directory /var/configs && \
-  [ -d /var/configs/$tmpDir ] && rm -rf $aggDir \
-    || (echo '$aggFile is invalid' && exit 1) && \
-  mv /var/configs/$tmpDir $aggDir"
-  rm -rf /var/configs/$tmpDir
+  [ -d /var/configs/${tmpDir} ] && rm -rf ${aggDir} \
+    || (echo '${aggFile} is invalid' && exit 1) && \
+  mv /var/configs/${tmpDir} ${aggDir}"
+  rm -rf /var/configs/"${tmpDir}"
 
-if [ $ro -eq 1 ]; then
+if [[ "${ro}" -eq 1 ]]; then
 # Set Environment Variable for DB_READ_ONLY so that we don't go through
 # derivation on the write db, and the read db persists.
-echo "  Setting environment variable on deployment/$deployName DB_READ_ONLY=true"
+echo "  Setting environment variable on deployment/${deployName} DB_READ_ONLY=true"
 echo "  WARNING: This environment variable will not persist a helm value change."
-kubectl set env deployment/$deployName DB_READ_ONLY=true
+kubectl set env deployment/"${deployName}" DB_READ_ONLY=true
 fi
 
 
 
 # Restart the application to pull ETL data into memory
 echo "Restarting the application"
-kubectl -n $namespace rollout restart deployment/$deployName
+kubectl -n "${namespace}" rollout restart deployment/"${deployName}"

--- a/aggregator-custom-query/query-aggregator.sh
+++ b/aggregator-custom-query/query-aggregator.sh
@@ -10,7 +10,7 @@ print_usage() {
 }
 
 # Check if at least two arguments are provided
-if [ $# -lt 2 ]; then
+if [[ $# -lt 2 ]]; then
     echo "Error: Namespace and query arguments are required."
     print_usage
     exit 1
@@ -23,13 +23,13 @@ shift
 QUERY=""
 
 # Parse arguments
-if [ "$1" == "--file" ]; then
-    if [ -z "$2" ]; then
+if [[ "$1" == "--file" ]]; then
+    if [[ -z "$2" ]]; then
         echo "Error: File path is missing after --file option."
         print_usage
         exit 1
     fi
-    if [ ! -f "$2" ]; then
+    if [[ ! -f "$2" ]]; then
         echo "Error: File '$2' not found."
         exit 1
     fi
@@ -38,45 +38,45 @@ else
     QUERY="$1"
 fi
 
-if [ -z "$NAMESPACE" ]; then
+if [[ -z "${NAMESPACE}" ]]; then
     echo "Namespace cannot be empty. Exiting."
     exit 1
 fi
 
 # Check if the provided namespace exists
-if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
-    echo "Namespace '$NAMESPACE' does not exist. Exiting."
+if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+    echo "Namespace '${NAMESPACE}' does not exist. Exiting."
     exit 1
 fi
 
 # Find the aggregator pod
-POD_NAME=$(kubectl get pods -n "$NAMESPACE" -o json | jq -r ".items[] | select(.spec.containers[].name == \"aggregator\") | .metadata.name")
+POD_NAME=$(kubectl get pods -n "${NAMESPACE}" -o json | jq -r ".items[] | select(.spec.containers[].name == \"aggregator\") | .metadata.name")
 
-if [ -z "$POD_NAME" ]; then
-    echo "No aggregator pod found in namespace $NAMESPACE"
+if [[ -z "${POD_NAME}" ]]; then
+    echo "No aggregator pod found in namespace ${NAMESPACE}"
     exit 1
 fi
 
-echo "Found aggregator pod: $POD_NAME"
+echo "Found aggregator pod: ${POD_NAME}"
 
 # Find the latest versioned folder
-LATEST_VERSION=$(kubectl exec -n "$NAMESPACE" $POD_NAME -c aggregator -- \
+LATEST_VERSION=$(kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c aggregator -- \
     sh -c "ls -d /var/configs/waterfowl/duckdb/v* | sort -V | tail -n 1")
 
-echo "Latest version folder: $LATEST_VERSION"
+echo "Latest version folder: ${LATEST_VERSION}"
 
 # Find the latest .read file
-LATEST_READ_FILE=$(kubectl exec -n "$NAMESPACE" $POD_NAME -c aggregator -- \
-    sh -c "ls -t $LATEST_VERSION/kubecost-*.duckdb.read | head -n 1")
+LATEST_READ_FILE=$(kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c aggregator -- \
+    sh -c "ls -t ${LATEST_VERSION}/kubecost-*.duckdb.read | head -n 1")
 
-echo "Latest .read file: $LATEST_READ_FILE"
+echo "Latest .read file: ${LATEST_READ_FILE}"
 
 # Execute the query
 #echo "Executing query: $QUERY"
-RESULT=$(kubectl exec -n "$NAMESPACE" $POD_NAME -c aggregator -- \
-    duckdb --readonly "$LATEST_READ_FILE" -csv -c "$QUERY")
+RESULT=$(kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c aggregator -- \
+    duckdb --readonly "${LATEST_READ_FILE}" -csv -c "${QUERY}")
 
 echo "Query result:"
-echo "$RESULT"
+echo "${RESULT}"
 
 echo "Script execution complete"

--- a/copy-alerts/copy-alerts.sh
+++ b/copy-alerts/copy-alerts.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Check if namespace argument is provided
-if [ $# -eq 0 ]; then
+if [[ $# -eq 0 ]]; then
     echo "Error: Namespace argument is required."
     echo "Usage: $0 <namespace>"
     exit 1
@@ -10,38 +10,41 @@ fi
 
 NAMESPACE=$1
 
-if [ -z "$NAMESPACE" ]; then
+if [[ -z "${NAMESPACE}" ]]; then
     echo "Namespace cannot be empty. Exiting."
     exit 1
 fi
 
 # Check if the provided namespace exists
-if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
-    echo "Namespace '$NAMESPACE' does not exist. Exiting."
+if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+    echo "Namespace '${NAMESPACE}' does not exist. Exiting."
     exit 1
 fi
 
 OLD_POD=''
 NEW_POD=''
-if [[ $(kubectl -n "$NAMESPACE" get sts -l app=aggregator 2>&1) == *"No resources found"* ]]; then
-    echo "No aggregator StatefulSet found with label 'app=aggregator' in namespace $NAMESPACE"
+
+sts_out=$(kubectl -n "${NAMESPACE}" get sts -l app=aggregator 2>&1)
+if [[ ${sts_out} == *"No resources found"* ]]; then
+    echo "No aggregator StatefulSet found with label 'app=aggregator' in namespace ${NAMESPACE}"
     # check if its single cluster deployment
-    if [ $(kubectl -n "$NAMESPACE" get service -l app=aggregator -o name | wc -l) -gt 0 ]; then
+    svc_out=$(kubectl -n "${NAMESPACE}" get service -l app=aggregator -o name | wc -l)
+    if [[ ${svc_out} -gt 0 ]]; then
         echo "default single cluster deployment"
-        OLD_POD=$(kubectl get pod -n "$NAMESPACE" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
-        NEW_POD=$OLD_POD
+        OLD_POD=$(kubectl get pod -n "${NAMESPACE}" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
+        NEW_POD=${OLD_POD}
     else
         echo "Unsupported alert transition"
         exit 1
     fi
 else
-    echo "Aggregator StatefulSet with label 'app=aggregator' found in namespace $NAMESPACE"
-    OLD_POD=$(kubectl get pod -n "$NAMESPACE" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
-    NEW_POD=$(kubectl get pod -n "$NAMESPACE" -l app=aggregator -o jsonpath='{.items[0].metadata.name}')
+    echo "Aggregator StatefulSet with label 'app=aggregator' found in namespace ${NAMESPACE}"
+    OLD_POD=$(kubectl get pod -n "${NAMESPACE}" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
+    NEW_POD=$(kubectl get pod -n "${NAMESPACE}" -l app=aggregator -o jsonpath='{.items[0].metadata.name}')
 fi
 
 # Check if OLD_POD and NEW_POD are not empty
-if [ -z "$OLD_POD" ] || [ -z "$NEW_POD" ]; then
+if [[ -z "${OLD_POD}" ]] || [[ -z "${NEW_POD}" ]]; then
     echo "Error: OLD_POD or NEW_POD is empty. Exiting."
     exit 1
 fi
@@ -52,33 +55,33 @@ TARGET_DIR="/var/configs/alerts"
 # In cost-model the alerts are stored as alerts.json and in aggregator alerts are stored as alerts-aggregator.json
 OLDFILENAME="/alerts.json"
 NEWFILENAME="/alerts-aggregator.json"
-TEMP_FILE="/tmp/$NEWFILENAME"
+TEMP_FILE="/tmp/${NEWFILENAME}"
 
 # Copy the content of the old file to the temporary file
-kubectl exec -n "$NAMESPACE" $OLD_POD -c cost-model -- cat "$SOURCE_DIR/$OLDFILENAME" > "$TEMP_FILE"
+kubectl exec -n "${NAMESPACE}" "${OLD_POD}" -c cost-model -- cat "${SOURCE_DIR}/${OLDFILENAME}" > "${TEMP_FILE}"
 
 # Ensure the target directory exists in aggregator container
-kubectl exec -i -n "$NAMESPACE" $NEW_POD -c aggregator -- sh -c "mkdir -p $TARGET_DIR"
+kubectl exec -i -n "${NAMESPACE}" "${NEW_POD}" -c aggregator -- sh -c "mkdir -p ${TARGET_DIR}"
 
 # Copy the content from the temporary file to the new file in the aggregator
-cat "$TEMP_FILE" | kubectl exec -i -n "$NAMESPACE" $NEW_POD -c aggregator -- sh -c "cat > $TARGET_DIR/$NEWFILENAME"
+kubectl exec -i -n "${NAMESPACE}" "${NEW_POD}" -c aggregator -- sh -c "cat > ${TARGET_DIR}/${NEWFILENAME}" < "${TEMP_FILE}"
 
 # Check the file is transitioned
-output=$(kubectl exec -it -n "$NAMESPACE" $NEW_POD -c aggregator -- ls -lh "$TARGET_DIR/$NEWFILENAME")
-line_count=$(echo "$output" | wc -l)
+output=$(kubectl exec -it -n "${NAMESPACE}" "${NEW_POD}" -c aggregator -- ls -lh "${TARGET_DIR}/${NEWFILENAME}")
+line_count=$(echo "${output}" | wc -l)
 
-if [ "$line_count" -eq 1 ]; then
+if [[ "${line_count}" -eq 1 ]]; then
     echo "File successfully copied and verified"
 else
     echo "Failed to copy, could not find the ${NEWFILENAME} in aggregator"
     exit 1
 fi
 
-rm -f "$TEMP_FILE"
+rm -f "${TEMP_FILE}"
 
 # Empty the old alerts file in cost-model
 # NOTE: Health alerts need to be enabled again on UI to get alerts from cost-model
-kubectl exec -it -n "$NAMESPACE" $OLD_POD -c cost-model -- sh -c "echo '{}' > '$SOURCE_DIR/$OLDFILENAME'"
+kubectl exec -it -n "${NAMESPACE}" "${OLD_POD}" -c cost-model -- sh -c "echo '{}' > '${SOURCE_DIR}/${OLDFILENAME}'"
 
 echo "Script run complete"
 

--- a/cve-scan/trivy.sh
+++ b/cve-scan/trivy.sh
@@ -27,16 +27,16 @@ get_kubecost_images() {
   | yq -r '.. | .image? | select(. != null)' | sort -u
 }
 kubecost_images=$(get_kubecost_images "$@")
-kubecost_images=$(echo "$kubecost_images" | grep -E '(/|\.)' || true)  # Filter lines with / or . (likely image names)
+kubecost_images=$(echo "${kubecost_images}" | grep -E '(/|\.)' || true)  # Filter lines with / or . (likely image names)
 
 # Remove the old results file
 rm -f "$(date +%Y-%m-%d)-trivy-results.txt"
 
 # Iterate over each image in kubecost_images
 # Use while read to handle multi-line input properly
-echo "$kubecost_images" | while IFS= read -r image; do
+echo "${kubecost_images}" | while IFS= read -r image; do
   # Skip empty lines
-  [ -z "$image" ] && continue
-  echo "Scanning: $image"
-  trivy image --format table --exit-code 1 --pkg-types os,library --severity CRITICAL,HIGH "$image" >> "$(date +%Y-%m-%d)-trivy-results.txt"
+  [[ -z "${image}" ]] && continue
+  echo "Scanning: ${image}"
+  trivy image --format table --exit-code 1 --pkg-types os,library --severity CRITICAL,HIGH "${image}" >> "$(date +%Y-%m-%d)-trivy-results.txt"
 done

--- a/diagnostics/json-output.sh
+++ b/diagnostics/json-output.sh
@@ -33,55 +33,55 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Set defaults if not provided
-if [ -z "$container" ]; then
+if [[ -z "${container}" ]]; then
   container="cost-model"
 fi
 
-if [ -z "$data_type" ]; then
+if [[ -z "${data_type}" ]]; then
   data_type="assets"
 fi
 
 # Validate container input
-if [ "$container" != "cost-model" ] && [ "$container" != "aggregator" ]; then
+if [[ "${container}" != "cost-model" ]] && [[ "${container}" != "aggregator" ]]; then
   echo "Container must be either 'cost-model' or 'aggregator'"
   exit 1
 fi
 
-if [ -z "$namespace" ]; then
+if [[ -z "${namespace}" ]]; then
   namespace=$(kubectl config view --minify -o jsonpath='{..namespace}')
-  if [ "$namespace" == "default" ] || [ "$namespace" == "" ]; then
+  if [[ "${namespace}" == "default" ]] || [[ "${namespace}" == "" ]]; then
     namespace=kubecost
   fi
 fi
 
-pod=$(kubectl get pods -n "$namespace" -o json | jq -r ".items[] | select(.spec.containers[].name == \"$container\") | .metadata.name")
+pod=$(kubectl get pods -n "${namespace}" -o json | jq -r ".items[] | select(.spec.containers[].name == \"${container}\") | .metadata.name")
 
-if ! [ -n "$pod" ]; then
-    echo "No pod found running $container container in namespace $namespace"
+if ! [[ -n "${pod}" ]]; then
+    echo "No pod found running ${container} container in namespace ${namespace}"
     exit 1
 fi
 
-latest_file=$(kubectl exec -i "$pod" -c $container -n "$namespace" -- ls -1t /var/configs/db/etl/bingen/$data_type/1d/ |head -n1 )
+latest_file=$(kubectl exec -i "${pod}" -c "${container}" -n "${namespace}" -- ls -1t /var/configs/db/etl/bingen/"${data_type}"/1d/ |head -n1 )
 
-if ! [ -n "$latest_file" ]; then
-    echo "No files found in /var/configs/db/etl/bingen/$data_type/1d/"
+if ! [[ -n "${latest_file}" ]]; then
+    echo "No files found in /var/configs/db/etl/bingen/${data_type}/1d/"
     exit 1
 fi
-my_file="/var/configs/db/etl/bingen/$data_type/1d/$latest_file"
+my_file="/var/configs/db/etl/bingen/${data_type}/1d/${latest_file}"
 
-my_output=$(kubectl exec --quiet -n "$namespace" "$pod" -c $container -- /go/bin/app bingentojson "$my_file")
+my_output=$(kubectl exec --quiet -n "${namespace}" "${pod}" -c "${container}" -- /go/bin/app bingentojson "${my_file}")
 # echo "my_output: $my_output"
 # Remove all text before the first {
-my_json=$(echo "$my_output" | sed '0,/{/s/^[^{]*//')
+my_json=$(echo "${my_output}" | sed '0,/{/s/^[^{]*//')
 
-if [ "$json_output" == "true" ]; then
-  echo "$my_json" 
+if [[ "${json_output}" == "true" ]]; then
+  echo "${my_json}" 
 else
-  echo "Namespace: $namespace"
-  echo "Finding pod running $container container..."
-  echo "Found pod running $container: $pod"
-  echo "Latest file found: $latest_file"
-  echo "my_file: $my_file"
-  echo "Running: kubectl exec --quiet -n \"$namespace\" \"$pod\" -c $container -- /go/bin/app bingentojson \"$my_file\""
-  echo "$my_json"
+  echo "Namespace: ${namespace}"
+  echo "Finding pod running ${container} container..."
+  echo "Found pod running ${container}: ${pod}"
+  echo "Latest file found: ${latest_file}"
+  echo "my_file: ${my_file}"
+  echo "Running: kubectl exec --quiet -n \"${namespace}\" \"${pod}\" -c ${container} -- /go/bin/app bingentojson \"${my_file}\""
+  echo "${my_json}"
 fi

--- a/diagnostics/log-collector.sh
+++ b/diagnostics/log-collector.sh
@@ -2,25 +2,25 @@
 
 # Temporary directory
 tmp_dir="/tmp/kubernetes_diagnostics"
-mkdir -p "$tmp_dir"
+mkdir -p "${tmp_dir}"
 
 # Execute kubectl commands
 execute_kubectl() {
     command=$1
-    output_file="$tmp_dir/$(echo $command | tr -s ' ' '_').yaml"
-    echo "Running command: kubectl $command"
-    kubectl $command -o yaml > "$output_file"
-    echo "Output saved to: $output_file"
+    output_file="${tmp_dir}/$(echo "${command}" | tr -s ' ' '_').yaml"
+    echo "Running command: kubectl ${command}"
+    kubectl "${command}" -o yaml > "${output_file}"
+    echo "Output saved to: ${output_file}"
     echo ""
 }
 
 # Execute helm command
 execute_helm() {
     command=$1
-    output_file="$tmp_dir/helm_values_kubecost.yaml"
-    echo "Running command: $command"
-    $command > "$output_file"
-    echo "Output saved to: $output_file"
+    output_file="${tmp_dir}/helm_values_kubecost.yaml"
+    echo "Running command: ${command}"
+    ${command} > "${output_file}"
+    echo "Output saved to: ${output_file}"
     echo ""
 }
 
@@ -44,15 +44,15 @@ kubectl_commands=(
 
 # Execute kubectl commands
 for cmd in "${kubectl_commands[@]}"; do
-    execute_kubectl "$cmd"
+    execute_kubectl "${cmd}"
 done
 
 # Execute helm command
 execute_helm "helm get values -a kubecost -n kubecost"
 
 # Zip all output files
-zip_file="$tmp_dir/kubernetes_diagnostics.zip"
-echo "Zipping all output files to: $zip_file"
-zip -j "$zip_file" "$tmp_dir"/*.yaml
-echo "Zip file created: $zip_file"
+zip_file="${tmp_dir}/kubernetes_diagnostics.zip"
+echo "Zipping all output files to: ${zip_file}"
+zip -j "${zip_file}" "${tmp_dir}"/*.yaml
+echo "Zip file created: ${zip_file}"
 

--- a/etl-backup/download-etl-gpgtar.sh
+++ b/etl-backup/download-etl-gpgtar.sh
@@ -6,13 +6,13 @@
 
 # Accept Optional Namespace -- default to kubecost
 namespace=$1
-if [ "$namespace" == "" ]; then
+if [[ "${namespace}" == "" ]]; then
   namespace=kubecost
 fi
 
 # Accept Optional ETL Store Directory -- default to /var/configs/db/etl
 etlDir=$2
-if [ "$etlDir" == "" ]; then
+if [[ "${etlDir}" == "" ]]; then
   etlDir=/var/configs/db/etl
 fi
 
@@ -20,23 +20,23 @@ fi
 currentContext=$(kubectl config current-context)
 
 echo "This script will download the Kubecost ETL storage using the following:"
-echo "  Kubectl Context: $currentContext"
-echo "  Namespace: $namespace"
-echo "  ETL Directory: $etlDir"
+echo "  Kubectl Context: ${currentContext}"
+echo "  Namespace: ${namespace}"
+echo "  ETL Directory: ${etlDir}"
 echo -n "Would you like to continue [y/N]? "
-read r
+read -r r
 
-if [ "$r" == "${r#[y]}" ]; then
+if [[ "${r}" == "${r#[y]}" ]]; then
   echo "Exiting..."
   exit 0
 fi
 
 # Grab the Pod Name of the cost-analyzer pod
-podName=$(kubectl get pods -n $namespace -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
+podName=$(kubectl get pods -n "${namespace}" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
 
 # Copy the Files to tmp directory
-echo "Copying ETL Files from $namespace/$podName:$etlDir to $tmpDir..."
-kubectl exec $podName -c cost-model -n $namespace -- gpgtar --skip-crypto -c -o -  -C /var/configs/db/etl .  > kubecost-etl.tar.gz 
+echo "Copying ETL Files from ${namespace}/${podName}:${etlDir} to a temp dir..."
+kubectl exec "${podName}" -c cost-model -n "${namespace}" -- gpgtar --skip-crypto -c -o -  -C /var/configs/db/etl .  > kubecost-etl.tar.gz 
 
 # Log final messages
 echo "ETL Archive Created: kubecost-etl.tar.gz"

--- a/etl-backup/download-etl-targeted.sh
+++ b/etl-backup/download-etl-targeted.sh
@@ -25,61 +25,61 @@
 
 # Accept Optional Namespace -- default to kubecost
 namespace=$1
-if [ "$namespace" == "" ]; then
+if [[ "${namespace}" == "" ]]; then
   namespace=kubecost
 fi
 
 # Accept Optional ETL Store Directory -- default to /var/configs/db/etl
 etlDir=$2
-if [ "$etlDir" == "" ]; then
+if [[ "${etlDir}" == "" ]]; then
   etlDir=/var/configs/db/etl
 fi
 
 # Accept Optional Window -- default to 10d
 window=$3
-if [ "$window" == "" ]; then
+if [[ "${window}" == "" ]]; then
   currentTime=$(date +%s)
   tenDaysAgo=$((currentTime - 10 * 24 * 60 * 60))
-  window=$tenDaysAgo
+  window=${tenDaysAgo}
 fi
 
 # Grab the Current Context for Prompt
-currentContext=`kubectl config current-context`
+currentContext=$(kubectl config current-context)
 
 echo "This script will download the Kubecost ETL storage using the following:"
-echo "  Kubectl Context: $currentContext"
-echo "  Namespace: $namespace"
-echo "  ETL Directory: $etlDir"
-echo "  Window: $window"
+echo "  Kubectl Context: ${currentContext}"
+echo "  Namespace: ${namespace}"
+echo "  ETL Directory: ${etlDir}"
+echo "  Window: ${window}"
 echo -n "Would you like to continue [y/N]? "
-read r
+read -r r
 
-if [ "$r" == "${r#[y]}" ]; then
+if [[ "${r}" == "${r#[y]}" ]]; then
   echo "Exiting..."
   exit 0
 fi
 
 # Grab the Pod Name of the cost-analyzer pod
-podName=`kubectl get pods -n $namespace -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}'`
+podName=$(kubectl get pods -n "${namespace}" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
 
 ################################################################################
 # Copy all relevant files to a temporary directory on the pod
 ################################################################################
 
-files=$(kubectl exec -n $namespace -c cost-model $podName -- sh -c "find $etlDir -type f")
+files=$(kubectl exec -n "${namespace}" -c cost-model "${podName}" -- sh -c "find ${etlDir} -type f")
 
 # Iterate through all files in etlDir, and copy all files older than the window
-for file in $files; do
+for file in ${files}; do
     # Extract the last part of the filepath, which contains timestamps
-    timestamps=$(basename "$file")
-    firstTimestamp=$(echo $timestamps | awk -F '-' '{print $1}')
+    timestamps=$(basename "${file}")
+    firstTimestamp=$(echo "${timestamps}" | awk -F '-' '{print $1}')
 
     # If the ETL file is older than the window, copy it to the temporary directory
-    if [ "$firstTimestamp" -gt "$window" ]; then
-        destPath=/var/configs/db/kc-etl-tmp$(dirname $file)  # concats tmpPodDir with the full ETL filepath
-        echo "Copying $file to $destPath ..."
-        kubectl exec -n $namespace -c cost-model $podName -- mkdir -p "$destPath"
-        kubectl exec -n $namespace -c cost-model $podName -- cp "$file" "$destPath"
+    if [[ "${firstTimestamp}" -gt "${window}" ]]; then
+        destPath=/var/configs/db/kc-etl-tmp$(dirname "${file}")  # concats tmpPodDir with the full ETL filepath
+        echo "Copying ${file} to ${destPath} ..."
+        kubectl exec -n "${namespace}" -c cost-model "${podName}" -- mkdir -p "${destPath}"
+        kubectl exec -n "${namespace}" -c cost-model "${podName}" -- cp "${file}" "${destPath}"
     fi
 done
 
@@ -88,15 +88,15 @@ done
 ################################################################################
 
 echo "Compressing ETL files ..."
-kubectl exec -n $namespace -c cost-model $podName -- tar cfz /var/configs/db/kubecost-etl.tar.gz /var/configs/db/kc-etl-tmp
+kubectl exec -n "${namespace}" -c cost-model "${podName}" -- tar cfz /var/configs/db/kubecost-etl.tar.gz /var/configs/db/kc-etl-tmp
 
 echo "Copying ETL Archive to local machine ..."
-kubectl cp -c cost-model $namespace/$podName:/var/configs/db/kubecost-etl.tar.gz kubecost-etl.tar.gz
+kubectl cp -c cost-model "${namespace}"/"${podName}":/var/configs/db/kubecost-etl.tar.gz kubecost-etl.tar.gz
 
 ################################################################################
 # Cleanup
 ################################################################################
 
 echo "Cleaning up tmp files created on pod ..."
-kubectl exec -n $namespace -c cost-model $podName -- rm -rf /var/configs/db/kc-etl-tmp
-kubectl exec -n $namespace -c cost-model $podName -- rm -rf /var/configs/db/kubecost-etl.tar.gz
+kubectl exec -n "${namespace}" -c cost-model "${podName}" -- rm -rf /var/configs/db/kc-etl-tmp
+kubectl exec -n "${namespace}" -c cost-model "${podName}" -- rm -rf /var/configs/db/kubecost-etl.tar.gz

--- a/etl-backup/download-etl.sh
+++ b/etl-backup/download-etl.sh
@@ -3,6 +3,7 @@
 # This script will use kubectl to copy the ETL backup directory to a temporary
 # location, then tar the contents and remove the tmp directory.
 #
+set -eo pipefail
 
 # Temporary Dir Name
 tmpDir=kc-etl-tmp
@@ -20,14 +21,14 @@ if [ "$etlDir" == "" ]; then
 fi
 
 # Grab the Current Context for Prompt
-currentContext=`kubectl config current-context`
+currentContext=$(kubectl config current-context)
 
 echo "This script will download the Kubecost ETL storage using the following:"
 echo "  Kubectl Context: $currentContext"
 echo "  Namespace: $namespace"
 echo "  ETL Directory: $etlDir"
 echo -n "Would you like to continue [y/N]? "
-read r
+read -r r
 
 if [ "$r" == "${r#[y]}" ]; then
   echo "Exiting..."
@@ -39,11 +40,16 @@ echo "Creating temporary directory $tmpDir..."
 mkdir $tmpDir
 
 # Grab the Pod Name of the cost-analyzer pod
-podName=`kubectl get pods -n $namespace -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}'`
+podName=$(kubectl get pods -n "$namespace" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
+
+# Create a kubectl debug container to use as an ephemeral passthrough
+# tar, used by kubectl cp, is no longer in Kubecost's base image 
+# we can remove this ephemeral container by restarting the deployment at the end of the script
+kubectl debug -n "$namespace"  "$podName" --image=busybox --container=ephemeral --target=cost-model --attach=false -- sh -c "sleep infinity"
 
 # Copy the Files to tmp directory
 echo "Copying ETL Files from $namespace/$podName:$etlDir to $tmpDir..."
-kubectl cp -c cost-model $namespace/$podName:$etlDir $tmpDir
+kubectl cp --container=ephemeral "$namespace"/"$podName":/proc/1/root"$etlDir" $tmpDir
 
 # Archive the directory
 tar cfz kubecost-etl.tar.gz $tmpDir
@@ -51,6 +57,18 @@ tar cfz kubecost-etl.tar.gz $tmpDir
 # Delete the temporary directory
 rm -rf $tmpDir
 
-# Log final messages
+# Log tar creation messages
 echo "ETL Archive Created: kubecost-etl.tar.gz"
 echo "Done"
+
+# Restart to remove the ephemeral container
+echo -n "Would you like to restart the Kubecost deployment to remove the ephemeral container [y/N]? "
+read -r r
+
+if [ "$r" == "${r#[y]}" ]; then
+  echo "Exiting..."
+  exit 0
+fi
+
+echo "Restarting the application"
+kubectl -n "$namespace" rollout restart deployment/kubecost-cost-analyzer

--- a/etl-backup/upload-etl.sh
+++ b/etl-backup/upload-etl.sh
@@ -3,6 +3,7 @@
 # This script will use kubectl to copy the ETL backup directory to a temporary
 # location, then tar the contents and remove the tmp directory.
 #
+set -eo pipefail
 
 # Accept Optional Namespace -- default to kubecost
 namespace=$1
@@ -16,6 +17,9 @@ if [ "$etlDir" == "" ]; then
   etlDir=/var/configs/db/etl
 fi
 
+# Hostpath used by ephemeral container
+hostpath=/proc/1/root  
+
 # Accept etl .tar file to upload
 etlFile=$3
 if [ "$etlFile" == "" ]; then
@@ -23,7 +27,7 @@ if [ "$etlFile" == "" ]; then
 fi
 
 # Grab the Current Context for Prompt
-currentContext=`kubectl config current-context`
+currentContext=$(kubectl config current-context)
 
 echo "This script will delete the Kubecost ETL storage and replace it with ETL files using the following:"
 echo "  Kubectl Context: $currentContext"
@@ -31,34 +35,37 @@ echo "  Namespace: $namespace"
 echo "  ETL File (source): $etlFile"
 echo "  ETL Directory (destination): $etlDir"
 echo -n "Would you like to continue [y/N]? "
-read r
+read -r r
 
 if [ "$r" == "${r#[y]}" ]; then
   echo "Exiting..."
   exit 0
 fi
 
-
 # Grab the Pod Name of the cost-analyzer pod
-podName=`kubectl get pods -n $namespace -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}'`
+podName=$(kubectl get pods -n "$namespace" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
 
 # Grab the Deployment name of the cost-analyzer pod
-deployName=`kubectl get deploy -n $namespace -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}'`
+deployName=$(kubectl get deploy -n "$namespace" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
 
-# Copy the Files to tmp directory
+# Create a kubectl debug container to use as an ephemeral passthrough
+# tar, used by kubectl cp, is no longer in Kubecost's base image 
+# we remove this ephemeral container by restarting the deployment at the end of the script
+kubectl debug -n "$namespace"  "$podName" --image=busybox --container=ephemeral --target=cost-model --attach=false -- sh -c "sleep infinity"
+
+# Copy the Files to tmp directory via the ephemeral container
 echo "Copying ETL Files from $etlFile to $podName..."
-kubectl cp -c cost-model $etlFile $namespace/$podName:/var/configs/kubecost-etl.tar.gz
+kubectl cp --container=ephemeral "$etlFile" "$namespace"/"$podName":"$hostpath"/var/configs/kubecost-etl.tar.gz
 
 # Exec into the pod and replace the ETL
 echo "Execing into the pod and replacing $etlDir "
-set -e
-kubectl exec -n $namespace pod/$podName -- sh -c " \
-  rm -rf /var/configs/kc-etl-tmp && \
-  tar xzf /var/configs/kubecost-etl.tar.gz --directory /var/configs && \
-  [ -d /var/configs/kc-etl-tmp ] && rm -rf $etlDir \
+kubectl exec -n "$namespace" pod/"$podName" --container=ephemeral -- sh -c " \
+  rm -rf $hostpath/var/configs/kc-etl-tmp && \
+  tar xzf $hostpath/var/configs/kubecost-etl.tar.gz --directory $hostpath/var/configs && \
+  [ -d $hostpath/var/configs/kc-etl-tmp ] && rm -rf $hostpath/$etlDir \
     || (echo '$etlFile is invalid' && exit 1) && \
-  mv /var/configs/kc-etl-tmp $etlDir"
+  mv $hostpath/var/configs/kc-etl-tmp $hostpath/$etlDir"
 
 # Restart the application to pull ETL data into memory
 echo "Restarting the application"
-kubectl -n $namespace rollout restart deployment/$deployName
+kubectl -n "$namespace" rollout restart deployment/"$deployName"

--- a/etl-backup/upload-etl.sh
+++ b/etl-backup/upload-etl.sh
@@ -7,13 +7,13 @@ set -eo pipefail
 
 # Accept Optional Namespace -- default to kubecost
 namespace=$1
-if [ "$namespace" == "" ]; then
+if [[ "${namespace}" == "" ]]; then
   namespace=kubecost
 fi
 
 # Accept Optional ETL Store Directory -- default to /var/configs/db/etl
 etlDir=$2
-if [ "$etlDir" == "" ]; then
+if [[ "${etlDir}" == "" ]]; then
   etlDir=/var/configs/db/etl
 fi
 
@@ -22,7 +22,7 @@ hostpath=/proc/1/root
 
 # Accept etl .tar file to upload
 etlFile=$3
-if [ "$etlFile" == "" ]; then
+if [[ "${etlFile}" == "" ]]; then
   etlFile=kubecost-etl.tar.gz
 fi
 
@@ -30,42 +30,42 @@ fi
 currentContext=$(kubectl config current-context)
 
 echo "This script will delete the Kubecost ETL storage and replace it with ETL files using the following:"
-echo "  Kubectl Context: $currentContext"
-echo "  Namespace: $namespace"
-echo "  ETL File (source): $etlFile"
-echo "  ETL Directory (destination): $etlDir"
+echo "  Kubectl Context: ${currentContext}"
+echo "  Namespace: ${namespace}"
+echo "  ETL File (source): ${etlFile}"
+echo "  ETL Directory (destination): ${etlDir}"
 echo -n "Would you like to continue [y/N]? "
 read -r r
 
-if [ "$r" == "${r#[y]}" ]; then
+if [[ "${r}" == "${r#[y]}" ]]; then
   echo "Exiting..."
   exit 0
 fi
 
 # Grab the Pod Name of the cost-analyzer pod
-podName=$(kubectl get pods -n "$namespace" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
+podName=$(kubectl get pods -n "${namespace}" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
 
 # Grab the Deployment name of the cost-analyzer pod
-deployName=$(kubectl get deploy -n "$namespace" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
+deployName=$(kubectl get deploy -n "${namespace}" -l app=cost-analyzer -o jsonpath='{.items[0].metadata.name}')
 
 # Create a kubectl debug container to use as an ephemeral passthrough
 # tar, used by kubectl cp, is no longer in Kubecost's base image 
 # we remove this ephemeral container by restarting the deployment at the end of the script
-kubectl debug -n "$namespace"  "$podName" --image=busybox --container=ephemeral --target=cost-model --attach=false -- sh -c "sleep infinity"
+kubectl debug -n "${namespace}"  "${podName}" --image=busybox --container=ephemeral --target=cost-model --attach=false -- sh -c "sleep infinity"
 
 # Copy the Files to tmp directory via the ephemeral container
-echo "Copying ETL Files from $etlFile to $podName..."
-kubectl cp --container=ephemeral "$etlFile" "$namespace"/"$podName":"$hostpath"/var/configs/kubecost-etl.tar.gz
+echo "Copying ETL Files from ${etlFile} to ${podName}..."
+kubectl cp --container=ephemeral "${etlFile}" "${namespace}"/"${podName}":"${hostpath}"/var/configs/kubecost-etl.tar.gz
 
 # Exec into the pod and replace the ETL
-echo "Execing into the pod and replacing $etlDir "
-kubectl exec -n "$namespace" pod/"$podName" --container=ephemeral -- sh -c " \
-  rm -rf $hostpath/var/configs/kc-etl-tmp && \
-  tar xzf $hostpath/var/configs/kubecost-etl.tar.gz --directory $hostpath/var/configs && \
-  [ -d $hostpath/var/configs/kc-etl-tmp ] && rm -rf $hostpath/$etlDir \
-    || (echo '$etlFile is invalid' && exit 1) && \
-  mv $hostpath/var/configs/kc-etl-tmp $hostpath/$etlDir"
+echo "Execing into the pod and replacing ${etlDir} "
+kubectl exec -n "${namespace}" pod/"${podName}" --container=ephemeral -- sh -c " \
+  rm -rf ${hostpath}/var/configs/kc-etl-tmp && \
+  tar xzf ${hostpath}/var/configs/kubecost-etl.tar.gz --directory ${hostpath}/var/configs && \
+  [ -d ${hostpath}/var/configs/kc-etl-tmp ] && rm -rf ${hostpath}/${etlDir} \
+    || (echo '${etlFile} is invalid' && exit 1) && \
+  mv ${hostpath}/var/configs/kc-etl-tmp ${hostpath}/${etlDir}"
 
 # Restart the application to pull ETL data into memory
 echo "Restarting the application"
-kubectl -n "$namespace" rollout restart deployment/"$deployName"
+kubectl -n "${namespace}" rollout restart deployment/"${deployName}"

--- a/settings-backup/backup-settings.sh
+++ b/settings-backup/backup-settings.sh
@@ -21,68 +21,68 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate container input
-if [ "$container" != "cost-model" ] && [ "$container" != "aggregator" ]; then
+if [[ "${container}" != "cost-model" ]] && [[ "${container}" != "aggregator" ]]; then
   echo "Container must be either 'cost-model' or 'aggregator'"
   exit 1
 fi
 
-if [ -z "$namespace" ]; then
+if [[ -z "${namespace}" ]]; then
   namespace=$(kubectl config view --minify -o jsonpath='{..namespace}')
-  if [ "$namespace" == "default" ] || [ "$namespace" == "" ]; then
+  if [[ "${namespace}" == "default" ]] || [[ "${namespace}" == "" ]]; then
     namespace=kubecost
   fi
 fi
-echo "Looking for pod running $container container in namespace $namespace"
+echo "Looking for pod running ${container} container in namespace ${namespace}"
 
-pod=$(kubectl get pods -n "$namespace" -o json | jq -r ".items[] | select(.spec.containers[].name == \"$container\") | .metadata.name")
+pod=$(kubectl get pods -n "${namespace}" -o json | jq -r ".items[] | select(.spec.containers[].name == \"${container}\") | .metadata.name")
 
-if ! [ -n "$pod" ]; then
-    echo "No pod found running $container container in namespace $namespace"
+if ! [[ -n "${pod}" ]]; then
+    echo "No pod found running ${container} container in namespace ${namespace}"
     exit 1
 fi
 
-mkdir -p $namespace-backup
-OUTPUT_DIR=$namespace-backup
+mkdir -p "${namespace}"-backup
+OUTPUT_DIR=${namespace}-backup
 
-FILES_TO_COPY=$(kubectl exec -n $namespace -c $container ${pod} -- ls -1 /var/configs/)
+FILES_TO_COPY=$(kubectl exec -n "${namespace}" -c "${container}" "${pod}" -- ls -1 /var/configs/)
 
-for file in $FILES_TO_COPY; do
-  if [[ $file == *.json ]]; then
-    kubectl exec -n $namespace -c $container ${pod} -- cat /var/configs/$file > $OUTPUT_DIR/$file
-    echo "Copied $file"
+for file in ${FILES_TO_COPY}; do
+  if [[ ${file} == *.json ]]; then
+    kubectl exec -n "${namespace}" -c "${container}" "${pod}" -- cat /var/configs/"${file}" > "${OUTPUT_DIR}"/"${file}"
+    echo "Copied ${file}"
   else
     continue
   fi
 done
 
 # copy alerts
-FILES_TO_COPY=$(kubectl exec -n $namespace -c $container ${pod} -- ls -1 /var/configs/alerts/)
+FILES_TO_COPY=$(kubectl exec -n "${namespace}" -c "${container}" "${pod}" -- ls -1 /var/configs/alerts/)
 
-for file in $FILES_TO_COPY; do
-  if [[ $file == *.json ]]; then
-    mkdir -p $OUTPUT_DIR/alerts
-    kubectl exec -n $namespace -c $container ${pod} -- cat /var/configs/alerts/$file > $OUTPUT_DIR/alerts/$file
-    echo "Copied $file"
+for file in ${FILES_TO_COPY}; do
+  if [[ ${file} == *.json ]]; then
+    mkdir -p "${OUTPUT_DIR}"/alerts
+    kubectl exec -n "${namespace}" -c "${container}" "${pod}" -- cat /var/configs/alerts/"${file}" > "${OUTPUT_DIR}"/alerts/"${file}"
+    echo "Copied ${file}"
   else
     continue
   fi
 done
 
 # copy cloud-integration
-FILES_TO_COPY=$(kubectl exec -n $namespace -c $container ${pod} -- ls -1 /var/configs/cloud-integration/)
+FILES_TO_COPY=$(kubectl exec -n "${namespace}" -c "${container}" "${pod}" -- ls -1 /var/configs/cloud-integration/)
 
-for file in $FILES_TO_COPY; do
-  if [[ $file == *.json ]]; then
-    mkdir -p $OUTPUT_DIR/cloud-integration
-    kubectl exec -n $namespace -c $container ${pod} -- cat /var/configs/cloud-integration/$file > $OUTPUT_DIR/cloud-integration/$file
-    echo "Copied $file"
+for file in ${FILES_TO_COPY}; do
+  if [[ ${file} == *.json ]]; then
+    mkdir -p "${OUTPUT_DIR}"/cloud-integration
+    kubectl exec -n "${namespace}" -c "${container}" "${pod}" -- cat /var/configs/cloud-integration/"${file}" > "${OUTPUT_DIR}"/cloud-integration/"${file}"
+    echo "Copied ${file}"
   else
     continue
   fi
 done
 
 # Remove empty configs
-find $OUTPUT_DIR -type f -size -3c -delete
+find "${OUTPUT_DIR}" -type f -size -3c -delete
 
-echo "The following files were copied to $OUTPUT_DIR"
-ls -l $OUTPUT_DIR
+echo "The following files were copied to ${OUTPUT_DIR}"
+ls -l "${OUTPUT_DIR}"

--- a/settings-backup/upload-settings.sh
+++ b/settings-backup/upload-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$2" ]; then
+if [[ -z "$2" ]]; then
   echo "Usage: $0 <namespace> <folder with settings to upload>"
   echo "Example: $0 kubecost ./kubecost-backup"
   exit 1
@@ -9,12 +9,12 @@ fi
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
-kubecost_aggregator=$(kubectl get pod -n $NAMESPACE -l app=aggregator -o jsonpath='{.items[0].metadata.name}')
+kubecost_aggregator=$(kubectl get pod -n "${NAMESPACE}" -l app=aggregator -o jsonpath='{.items[0].metadata.name}')
 
-for file in $OUTPUT_DIR/*; do
-  if [ -f $file ]; then
-    echo "Uploading $(basename "$file")"
-    cat "$file" | kubectl exec -i -n "$NAMESPACE" $kubecost_aggregator -c aggregator -- sh -c "cat > /var/configs/$(basename "$file")"
-    echo "Uploaded $(basename "$file")"
+for file in ${OUTPUT_DIR}/*; do
+  if [[ -f "${file}" ]]; then
+    echo "Uploading $(basename "${file}")"
+    cat "${file}" | kubectl exec -i -n "${NAMESPACE}" "${kubecost_aggregator}" -c aggregator -- sh -c "cat > /var/configs/$(basename "${file}")"
+    echo "Uploaded $(basename "${file}")"
   fi
 done


### PR DESCRIPTION
## Issues
- the newest image of Kubecost does not contain the `tar` binary. `kubectl cp` uses tar to stream data to and from a local machine.
- missing shellcheck linting for scripts

## Change Log

- Updated the `upload-etl.sh` and `download-etl.sh` scripts to support using an ephemeral container to copy data to/from a Kubecost pod
- Added a Github action to perform `make shellcheck` which lints all `*.sh` files in the repo
- Added a Makefile so that any one can easily run shellcheck locally
- Fixed easy shellcheck recommendations for the 13 scripts in the repo, dropping the overall number of lint issues from hundreds to around a dozen.

## Tests
- to test the ETL scripts, I deployed Kubecost on a a replicated cluster. I downloaded the existing data, copied in the sample data, and then ran the upload script. After the Kubecost pod restarts, the sample ETL data was viewable in the UI
- all other shellcheck changes were minimal and do not change the original logic  