### PR TITLE
[KCM/3873] - Rename Helm Chart from cost-analyzer to kubecost

### DIFF
--- a/cve-scan/trivy.sh
+++ b/cve-scan/trivy.sh
@@ -20,7 +20,7 @@ fi
 
 # Capture the output of kai and store it in kubecost_images
 get_kubecost_images() {
-  helm template kubecost --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer \
+  helm template kubecost --repo https://kubecost.github.io/cost-analyzer/ kubecost \
   --set networkCosts.enabled=true \
   --set clusterController.enabled=true \
   --skip-tests "$@" \


### PR DESCRIPTION
Updated Helm chart name for Trivy scan. 